### PR TITLE
Update thing-types.xml

### DIFF
--- a/org.openhab.binding.greeair/ESH-INF/thing/thing-types.xml
+++ b/org.openhab.binding.greeair/ESH-INF/thing/thing-types.xml
@@ -1,32 +1,97 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <thing:thing-descriptions bindingId="greeair"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
-	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+						  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+						  xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+						  xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
 
-	<!-- Sample Thing Type -->
-	<thing-type id="sample">
-		<label>GreeAir Binding Thing</label>
-		<description>Sample thing for GreeAir Binding</description>
+	<!--The one and only supported thing type-->
+	<thing-type id="greeairthing">
+		<label>Gree AirConditioner</label>
+		<description>Gree AirConditioner</description>
 
 		<channels>
-			<channel id="channel1" typeId="sample-channel" />
+			<channel id="powerchannel" typeId="power-channel"/><channel typeId="mode-channel" id="modechannel"></channel>
+			<channel typeId="turbo-channel" id="turbochannel"></channel>
+			<channel typeId="light-channel" id="lightchannel"></channel>
+			<channel typeId="temp-channel" id="tempchannel"></channel>
+			<channel typeId="swingvertical-channel" id="swingverticalchannel"></channel>
+			<channel typeId="windspeed-channel" id="windspeedchannel"></channel>
+			<channel typeId="air-channel" id="airchannel"></channel>
+			<channel typeId="dry-channel" id="drychannel"></channel>
+			<channel typeId="health-channel" id="healthchannel"></channel>
+			<channel typeId="pwrsav-channel" id="pwrsavchannel"></channel>
 		</channels>
-
 		<config-description>
-			<parameter name="config1" type="text" required="true">
-				<label>Sample parameter</label>
-				<description>This is a sample text configuration parameter.</description>
+			<parameter name="ipAddress" type="text" required="true">
+				<label>Network Address</label>
+				<description>Enter the IP address of the Gree Airconditioner</description>
+				<context>network-address</context></parameter>
+			<parameter name="refresh" type="integer" required="true">
+				<label>Refresh time interval</label>
+				<description>Refresh time interval in seconds.</description>
+				<default>1</default>
 			</parameter>
-		</config-description>
-
+			<parameter name="broadcastAddress" type="text" required="true">
+				<label>Broadcast Address</label>
+				<description>Enter the network Broadcast IP for your network</description>
+				<context>network-address</context>
+				<default>255.255.255.255</default></parameter></config-description>
 	</thing-type>
 
-	<!-- Sample Channel Type -->
-	<channel-type id="sample-channel">
-		<item-type>greeairItem</item-type>
-		<label>GreeAir Binding Channel</label>
-		<description>Sample channel for GreeAir Binding</description>
+	<!--Binding channels-->
+	<channel-type id="power-channel">
+		<item-type>Switch</item-type>
+		<label>Power</label>
+		<description>Power channel for GreeAir Binding</description>
+	</channel-type>
+	<channel-type id="mode-channel">
+		<item-type>Number</item-type>
+		<label>Mode</label>
+		<description>Mode Channel for Gree Air Binding. Mode: Auto: 0, Cool: 1, Dry: 2, Fan: 3, Heat: 4</description>
+	</channel-type>
+	<channel-type id="turbo-channel">
+		<item-type>Switch</item-type>
+		<label>Turbo</label>
+		<description>Turbo Fan Channel for Gree Air Ninding</description>
+	</channel-type>
+	<channel-type id="light-channel">
+		<item-type>Switch</item-type>
+		<label>Light</label>
+		<description>Light Channel for Gree Air Binding</description>
+	</channel-type>
+	<channel-type id="temp-channel">
+		<item-type>Number</item-type>
+		<label>Temperature</label>
+		<description>Temperature Channel for Gree Air Binding</description>
+	</channel-type>
+	<channel-type id="swingvertical-channel">
+		<item-type>Number</item-type>
+		<label>Vertical Swing</label><description>Vertical Swing Channel for Gree Air Binding. Swing: Full: 1, Up: 2, MidUp: 3, Mid: 4, Mid Down: 5, Down : 6</description>
+	</channel-type>
+	<channel-type id="windspeed-channel">
+		<item-type>Number</item-type>
+		<label>Fan Speed</label>
+		<description>Fan Speed Channel for Gree Air binding. Auto:0, Low:1, Midlow:2, Mid:3, MidHigh:4, High:5</description>
+	</channel-type>
+	<channel-type id="air-channel">
+		<item-type>Switch</item-type>
+		<label>Air</label>
+		<description>Air Channel for Gree Air Binding</description>
+	</channel-type>
+	<channel-type id="dry-channel">
+		<item-type>Switch</item-type>
+		<label>Dry</label>
+		<description>Dry Channel for Gree Air Binding</description>
+	</channel-type>
+	<channel-type id="health-channel">
+		<item-type>Switch</item-type>
+		<label>Health</label>
+		<description>Health Channel for Gree Air Binding</description>
+	</channel-type>
+	<channel-type id="pwrsav-channel">
+		<item-type>Switch</item-type>
+		<label>Power Saving</label>
+		<description>Pwer Saving Channel for Gree Air Binding</description>
 	</channel-type>
 
 </thing:thing-descriptions>


### PR DESCRIPTION
`thing-types.xml` was a sample file, reverting it to proper (see [post 55](https://community.openhab.org/t/new-gree-air-conditioner-binding/36429/55) )